### PR TITLE
Add the optional AffectedResourceString attribute

### DIFF
--- a/report.go
+++ b/report.go
@@ -112,10 +112,11 @@ func (r Report) Validate() error {
 type Vulnerability struct {
 	ID string `json:"id"` // Arbitrary UUID that uniquely identifies the vulnerability in every scan.
 
-	Summary          string  `json:"summary"`           // Mandatory. Vulnerability title.
-	Score            float32 `json:"score"`             // Vulnerability severity score. According to CVSSv3 base score.
-	AffectedResource string  `json:"affected_resource"` // Indicates the concrete resource affected by the vulnerability.
-	Fingerprint      string  `json:"fingerprint"`       // Fingerprint defines the context in where the vulnerability has been found.
+	Summary                string  `json:"summary"`                  // Mandatory. Vulnerability title.
+	Score                  float32 `json:"score"`                    // Vulnerability severity score. According to CVSSv3 base score.
+	AffectedResource       string  `json:"affected_resource"`        // Indicates the concrete resource affected by the vulnerability.
+	AffectedResourceString string  `json:"affected_resource_string"` // Optionally indicates a human-readable meaningful version of the AffectedResource.
+	Fingerprint            string  `json:"fingerprint"`              // Fingerprint defines the context in where the vulnerability has been found.
 
 	CWEID         uint32   `json:"cwe_id,omitempty"`         // CWE-ID.
 	Description   string   `json:"description,omitempty"`    // Vulnerability description.

--- a/report_test.go
+++ b/report_test.go
@@ -194,9 +194,10 @@ func TestValidateVulnerability(t *testing.T) {
 		{
 			name: "HappyPathWithSubvulnerabilities",
 			v: Vulnerability{
-				Summary:          "vulnerability with subvulns",
-				AffectedResource: "port-80",
-				Score:            8.9,
+				Summary:                "vulnerability with subvulns",
+				AffectedResource:       "1234567",
+				AffectedResourceString: "port-80",
+				Score:                  8.9,
 				Vulnerabilities: []Vulnerability{
 					vulnerabilityWithScore(6.9),
 				},


### PR DESCRIPTION
Add the `AffectedResourceString` attribute that optionally indicates a
human-readable meaningful version of the AffectedResource.